### PR TITLE
fix setState(()=>{})

### DIFF
--- a/src/hooks/state.ts
+++ b/src/hooks/state.ts
@@ -28,10 +28,8 @@ export function useState<T>(defaultState: State<T>): [T, SetState<T>] {
         }
 
         componentSetters[counter] = (state, callback?) => {
-            const componentState: { [counter: number]: T } = component.state
             if (typeof state === 'function') {
-                const oldState = componentState[counter] as T
-                component.setState({ [counter]: (state as (oldState: T) => T)(oldState) }, callback)
+                component.setState((newState) => ({ [counter]: state(newState) }), callback)
             } else {
                 component.setState({ [counter]: state }, callback)
             }


### PR DESCRIPTION
复现例子：正常情况下 onSetCount 执行 ，count+2，目前是+1。
```ts
import React from 'react';
import { withHooks, useState } from 'blx-react-hooks'

export const Counter = withHooks(function () {
  const [count, setCount] = useState(0)

  const onSetCount = () => {
    setCount((count) => count + 1)
    setCount((count) => count + 1)
  }

  return (
    <div>
      <button onClick={onSetCount}> - </button>
      Count: {count}
    </div>
  )
})
```