### PR TITLE
优化inputs在NaN时意外刷新

### DIFF
--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -6,7 +6,7 @@ export function inputsChange(oldInputs: HooksInputs, newInputs: HooksInputs) {
         if (oldInputs.length > 0 && newInputs.length > 0) {
             if (oldInputs.length === newInputs.length) {
                 for (let i = 0, l = oldInputs.length; i < l; i++) {
-                    if (oldInputs[i] !== newInputs[i]) {
+                    if (!Object.is(oldInputs[i], newInputs[i]) ) {
                         return true
                     }
                 }

--- a/test/inputs.ts
+++ b/test/inputs.ts
@@ -10,3 +10,4 @@ assert.equal(inputsChange([1], [1, 2]), true)
 const obj = {}
 assert.equal(inputsChange([obj], [obj]), false)
 assert.equal(inputsChange([1, 2, 3], [1, 2, 3]), false)
+assert.equal(inputsChange([NaN], [NaN]), false)


### PR DESCRIPTION
优化inpus项为NaN时候意外刷新问题
```jsx
const App = withHooks(function App({}){
    const [num, update] = useState(0);
    const [notShouldUpdate] = useState(0 / 0)
    useEffect(() => {
        console.log('update notShouldUpdate');
    }, [notShouldUpdate])
    return <div onClick={() => update(num + 1)}>{num}</div>
})
```